### PR TITLE
[Create Beam Link] Remove copy link to clipboard after creating link

### DIFF
--- a/ui/components/beam/screen/BeamGetPaid.js
+++ b/ui/components/beam/screen/BeamGetPaid.js
@@ -157,9 +157,6 @@ export const BeamGetPaid = ({ setBgColor, setHashtags }) => {
       if (result.ok) {
         const id = result.ok
         setBeamOutId(id)
-
-        const link = beamOutLink(id)
-        await copyLinkToClipboard(link)
       } else if (result.err) {
         log.error(result.err)
         throw new Error(result.err)
@@ -341,7 +338,7 @@ export const BeamGetPaid = ({ setBgColor, setHashtags }) => {
                     <BeamGradientActionButton
                       title={
                         beamOutId != null
-                          ? "Link Copied"
+                          ? "Copy Link"
                           : "Create Unique Beam Link"
                       }
                       textSize={{ base: "15px", md: "20px" }}


### PR DESCRIPTION
... to solve browser copy to clipboard issue in Chrome and Brave due to action is only allowed from user interaction event